### PR TITLE
Add possibility to supply extra hadoop args.

### DIFF
--- a/lib/humboldt/emr_flow.rb
+++ b/lib/humboldt/emr_flow.rb
@@ -5,8 +5,9 @@ module Humboldt
     attr_reader :output_path
 
     def initialize(*args)
-      @job_name, @input_glob, @package, @emr, @data_bucket, @job_bucket, @output_path = args
+      @job_name, @input_glob, @package, @emr, @data_bucket, @job_bucket, @output_path, @extra_job_args = args
       @output_path ||= "#{@package.project_name}/#{@job_name}/output"
+      @extra_job_args ||= []
     end
 
     def prepare!
@@ -133,7 +134,8 @@ module Humboldt
           :args => [
             @job_name,
             s3_uri(@input_glob, protocol: 's3n', bucket: @data_bucket),
-            s3_uri(output_path, protocol: 's3n')
+            s3_uri(output_path, protocol: 's3n'),
+            *@extra_job_args
           ]
         }
       }

--- a/spec/humboldt/emr_flow_spec.rb
+++ b/spec/humboldt/emr_flow_spec.rb
@@ -154,6 +154,17 @@ module Humboldt
           }]
         end
 
+        describe 'with extra job arguments' do
+          let :flow do
+            described_class.new('some_job', 'input_glob/*/*', package, emr, data_bucket, job_bucket, 'my_awesome_job/some_job/output', ['foo', 'bar'])
+          end
+
+          it 'configures the job flow steps to include the extra arguments' do
+            flow.run!
+            @configuration[:steps][0][:hadoop_jar_step][:args][3..4].should == ['foo', 'bar']
+          end
+        end
+
         it 'configures the instances' do
           flow.run!
           @configuration[:instances].should == {


### PR DESCRIPTION
Extra arguments can now be supplied using the `--extra-hadoop-args` option. They are passed on to Hadoop, and thus available as arguments to the `Rubydoop.configure` block.

I've tested it with `run-local`, but not yet with `run-emr` - will do as soon as I have a real job to run.

@iconara Would you mind looking at this?
