### PR TITLE
Add missing rspec helper class FakeCounter

### DIFF
--- a/lib/humboldt/rspec.rb
+++ b/lib/humboldt/rspec.rb
@@ -93,6 +93,16 @@ module RunnerHelpers
       end
     end
   end
+
+  class FakeCounter
+    def initialize(&block)
+      @block = block
+    end
+
+    def increment(*args)
+      @block.call(*args)
+    end
+  end
 end
 
 RSpec.configure do |conf|


### PR DESCRIPTION
The class was probably missed while porting the rspec helpers, resulting
in a NameError when running specs for mappers/reducers using counters.
