### PR TITLE
Implement type converters in Java

### DIFF
--- a/ext/src/HumboldtService.java
+++ b/ext/src/HumboldtService.java
@@ -1,0 +1,6 @@
+public class HumboldtService implements org.jruby.runtime.load.BasicLibraryService {
+  public boolean basicLoad(final org.jruby.Ruby runtime) throws java.io.IOException {
+    humboldt.TypeConverters.load(runtime);
+    return true;
+  }
+}

--- a/ext/src/HumboldtService.java
+++ b/ext/src/HumboldtService.java
@@ -1,6 +1,0 @@
-public class HumboldtService implements org.jruby.runtime.load.BasicLibraryService {
-  public boolean basicLoad(final org.jruby.Ruby runtime) throws java.io.IOException {
-    humboldt.TypeConverters.load(runtime);
-    return true;
-  }
-}

--- a/ext/src/humboldt/HumboldtLibrary.java
+++ b/ext/src/humboldt/HumboldtLibrary.java
@@ -1,0 +1,7 @@
+package humboldt;
+
+public class HumboldtLibrary implements org.jruby.runtime.load.Library {
+  public void load(final org.jruby.Ruby runtime, final boolean wrap) throws java.io.IOException {
+    humboldt.TypeConverters.load(runtime);
+  }
+}

--- a/ext/src/humboldt/TypeConverters.java
+++ b/ext/src/humboldt/TypeConverters.java
@@ -1,0 +1,268 @@
+package humboldt;
+
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyInteger;
+import org.jruby.RubyModule;
+import org.jruby.RubyObject;
+import org.jruby.RubyString;
+import org.jruby.anno.JRubyClass;
+import org.jruby.anno.JRubyMethod;
+import org.jruby.exceptions.RaiseException;
+import org.jruby.javasupport.Java;
+import org.jruby.javasupport.JavaUtil;
+import org.jruby.runtime.ObjectAllocator;
+import org.jruby.runtime.ThreadContext;
+import org.jruby.runtime.builtin.IRubyObject;
+import org.jruby.util.ByteList;
+
+import org.jcodings.specific.ASCIIEncoding;
+import org.jcodings.specific.USASCIIEncoding;
+import org.jcodings.specific.UTF8Encoding;
+
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+
+public class TypeConverters {
+  public static void load(Ruby runtime) {
+    RubyModule humboldtModule = runtime.defineModule("Humboldt");
+    RubyModule typeConverterModule = runtime.defineModuleUnder("TypeConverter", humboldtModule);
+    RubyClass binaryClass = runtime.defineClassUnder("Binary", runtime.getObject(), BINARY_ALLOCATOR, typeConverterModule);
+    binaryClass.defineAnnotatedMethods(BinaryConverter.class);
+    runtime.defineClassUnder("Encoded", binaryClass, BINARY_ALLOCATOR, typeConverterModule);
+    RubyClass textClass = runtime.defineClassUnder("Text", runtime.getObject(), TEXT_ALLOCATOR, typeConverterModule);
+    textClass.defineAnnotatedMethods(TextConverter.class);
+    runtime.defineClassUnder("Json", textClass, TEXT_ALLOCATOR, typeConverterModule);
+    RubyClass longClass = runtime.defineClassUnder("Long", runtime.getObject(), LONG_ALLOCATOR, typeConverterModule);
+    longClass.defineAnnotatedMethods(LongConverter.class);
+    RubyClass noneClass = runtime.defineClassUnder("None", runtime.getObject(), NONE_ALLOCATOR, typeConverterModule);
+    noneClass.defineAnnotatedMethods(NoneConverter.class);
+  }
+
+  private static final ObjectAllocator BINARY_ALLOCATOR = new ObjectAllocator() {
+    @Override
+    public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+      return new BinaryConverter(runtime, klass);
+    }
+  };
+
+  private static final ObjectAllocator TEXT_ALLOCATOR = new ObjectAllocator() {
+    @Override
+    public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+      return new TextConverter(runtime, klass);
+    }
+  };
+
+  private static final ObjectAllocator LONG_ALLOCATOR = new ObjectAllocator() {
+    @Override
+    public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+      return new LongConverter(runtime, klass);
+    }
+  };
+
+  private static final ObjectAllocator NONE_ALLOCATOR = new ObjectAllocator() {
+    @Override
+    public IRubyObject allocate(Ruby runtime, RubyClass klass) {
+      return new NoneConverter(runtime, klass);
+    }
+  };
+
+  private static final RaiseException newTypeError(final Ruby runtime, final RubyClass actual, final String expected) {
+    return runtime.newTypeError("Hadoop type mismatch, was " + actual.to_s() + ", expected " + expected);
+  }
+
+  private static final Object unwrapJavaObject(final IRubyObject arg) {
+    if(JavaUtil.isJavaObject(arg)) {
+      return JavaUtil.unwrapJavaObject(arg);
+    } else {
+      return null;
+    }
+  }
+
+  @JRubyClass(name="Humboldt::TypeConverter::Binary")
+  public static class BinaryConverter extends RubyObject {
+    private BytesWritable value = new BytesWritable();
+
+    public BinaryConverter(Ruby runtime, RubyClass klass) {
+      super(runtime, klass);
+    }
+
+    @JRubyMethod(name="hadoop")
+    public IRubyObject hadoop(final ThreadContext ctx) {
+      return Java.getInstance(ctx.runtime, value);
+    }
+
+    @JRubyMethod(name="hadoop=")
+    public IRubyObject hadoop_set(final ThreadContext ctx, IRubyObject arg) {
+      Object object = unwrapJavaObject(arg);
+      if (object == null) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::BytesWritable");
+      } else {
+        try {
+          value = (BytesWritable)object;
+        } catch (ClassCastException cce) {
+          throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::BytesWritable");
+        }
+      }
+      return arg;
+    }
+
+    @JRubyMethod(name="ruby")
+    public IRubyObject ruby(final ThreadContext ctx) {
+      RubyString string = RubyString.newString(ctx.runtime, value.getBytes(), 0, value.getLength());
+      string.setEncoding(ASCIIEncoding.INSTANCE);
+      return string;
+    }
+
+    @JRubyMethod(name = "ruby=", required = 1)
+    public IRubyObject ruby_set(final ThreadContext ctx, IRubyObject arg) {
+      RubyString string;
+      try {
+        string = arg.convertToString();
+      } catch (RaiseException re) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "String");
+      }
+      ByteList bytes = string.getByteList();
+      value.set(bytes.getUnsafeBytes(), bytes.getBegin(), bytes.getRealSize());
+      return arg;
+    }
+  }
+
+  @JRubyClass(name="Humboldt::TypeConverter::Text")
+  public static class TextConverter extends RubyObject {
+    Text value = new Text();
+
+    public TextConverter(Ruby runtime, RubyClass klass) {
+      super(runtime, klass);
+    }
+
+    @JRubyMethod(name="hadoop")
+    public IRubyObject hadoop(final ThreadContext ctx) {
+      return Java.getInstance(ctx.runtime, value);
+    }
+
+    @JRubyMethod(name="hadoop=")
+    public IRubyObject hadoop_set(final ThreadContext ctx, IRubyObject arg) {
+      Object object = unwrapJavaObject(arg);
+      if (object == null) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::Text");
+      } else {
+        try {
+          value = (Text)object;
+        } catch (ClassCastException cce) {
+          throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::Text");
+        }
+      }
+      return arg;
+    }
+
+    @JRubyMethod(name="ruby")
+    public IRubyObject ruby(final ThreadContext ctx) {
+      RubyString string = RubyString.newString(ctx.runtime, value.getBytes(), 0, value.getLength());
+      string.setEncoding(UTF8Encoding.INSTANCE);
+      return string;
+    }
+
+    @JRubyMethod(name="ruby=")
+    public IRubyObject ruby_set(final ThreadContext ctx, IRubyObject arg) {
+      RubyString string;
+      try {
+        string = arg.convertToString();
+      } catch (RaiseException re) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "String");
+      }
+      if (string.getEncoding() == UTF8Encoding.INSTANCE || string.getEncoding() == USASCIIEncoding.INSTANCE) {
+        ByteList bytes = string.getByteList();
+        value.set(bytes.getUnsafeBytes(), bytes.getBegin(), bytes.getRealSize());
+      } else {
+        value.set(string.toString());
+      }
+      return arg;
+    }
+  }
+
+  @JRubyClass(name="Humboldt::TypeConverter::Long")
+  public static class LongConverter extends RubyObject {
+    private LongWritable value = new LongWritable();
+
+    public LongConverter(Ruby runtime, RubyClass klass) {
+      super(runtime, klass);
+    }
+
+    @JRubyMethod(name="hadoop")
+    public IRubyObject hadoop(final ThreadContext ctx) {
+      return Java.getInstance(ctx.runtime, value);
+    }
+
+    @JRubyMethod(name="hadoop=")
+    public IRubyObject hadoop_set(final ThreadContext ctx, IRubyObject arg) {
+      Object object = unwrapJavaObject(arg);
+      if (object == null) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::LongWritable");
+      } else {
+        try {
+          value = (LongWritable)object;
+        } catch (ClassCastException cce) {
+          throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::LongWritable");
+        }
+      }
+      return arg;
+    }
+
+    @JRubyMethod(name="ruby")
+    public IRubyObject ruby(final ThreadContext ctx) {
+      return ctx.runtime.newFixnum(value.get());
+    }
+
+    @JRubyMethod(name="ruby=")
+    public IRubyObject ruby_set(final ThreadContext ctx, IRubyObject arg) {
+      long temp = 0;
+      try {
+        temp = ((RubyInteger)arg).getLongValue();
+      } catch (ClassCastException cce) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "Fixnum");
+      } catch (RaiseException re) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "Fixnum");
+      }
+      value.set(temp);
+      return arg;
+    }
+  }
+
+  @JRubyClass(name="Humboldt::TypeConverter::None")
+  public static class NoneConverter extends RubyObject {
+    public NoneConverter(Ruby runtime, RubyClass klass) {
+      super(runtime, klass);
+    }
+
+    @JRubyMethod(name="hadoop")
+    public IRubyObject hadoop(final ThreadContext ctx) {
+      return Java.getInstance(ctx.runtime, NullWritable.get());
+    }
+
+    @JRubyMethod(name="hadoop=")
+    public IRubyObject hadoop_set(final ThreadContext ctx, IRubyObject arg) {
+      Object object = unwrapJavaObject(arg);
+      if (object == null || !(object instanceof NullWritable)) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "Hadoop::Io::NullWritable");
+      }
+      return arg;
+    }
+
+    @JRubyMethod(name="ruby")
+    public IRubyObject ruby(final ThreadContext ctx) {
+      return ctx.runtime.getNil();
+    }
+
+    @JRubyMethod(name="ruby=")
+    public IRubyObject ruby_set(final ThreadContext ctx, IRubyObject arg) {
+      if (!arg.isNil()) {
+        throw newTypeError(ctx.runtime, arg.getMetaClass(), "NilClass");
+      }
+      return arg;
+    }
+  }
+}

--- a/lib/humboldt.rb
+++ b/lib/humboldt.rb
@@ -14,3 +14,5 @@ require 'humboldt/processor'
 require 'humboldt/mapper'
 require 'humboldt/reducer'
 require 'humboldt/prefix_grouping'
+
+require 'humboldt.jar'

--- a/lib/humboldt.rb
+++ b/lib/humboldt.rb
@@ -4,6 +4,9 @@ require 'fileutils'
 require 'rubydoop'
 require 'hadoop'
 
+$CLASSPATH << File.expand_path('../humboldt.jar', __FILE__)
+Java::Humboldt::HumboldtLibrary.new.load(JRuby.runtime, false)
+
 require 'humboldt/java_lib'
 
 require 'ext/hadoop'
@@ -14,6 +17,3 @@ require 'humboldt/processor'
 require 'humboldt/mapper'
 require 'humboldt/reducer'
 require 'humboldt/prefix_grouping'
-
-$CLASSPATH << File.expand_path('../humboldt.jar', __FILE__)
-Java::Humboldt::HumboldtLibrary.new.load(JRuby.runtime, false)

--- a/lib/humboldt.rb
+++ b/lib/humboldt.rb
@@ -15,4 +15,5 @@ require 'humboldt/mapper'
 require 'humboldt/reducer'
 require 'humboldt/prefix_grouping'
 
-require 'humboldt.jar'
+$CLASSPATH << File.expand_path('../humboldt.jar', __FILE__)
+Java::Humboldt::HumboldtLibrary.new.load(JRuby.runtime, false)

--- a/lib/humboldt/type_converters.rb
+++ b/lib/humboldt/type_converters.rb
@@ -40,13 +40,11 @@ module Humboldt
           unless value.is_a?(Hash) || value.is_a?(Array)
             raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected Hash or Array"
           end
-          packed = MessagePack.pack(value)
-          @hadoop.set(packed.to_java_bytes, 0, packed.bytesize)
+          super(MessagePack.pack(value))
         end
 
         def ruby
-          packed = String.from_java_bytes(@hadoop.bytes).byteslice(0, @hadoop.length)
-          MessagePack.unpack(packed, encoding: Encoding::UTF_8)
+          MessagePack.unpack(super(), encoding: Encoding::UTF_8)
         end
       end
     rescue LoadError
@@ -94,11 +92,11 @@ module Humboldt
           unless value.is_a?(Hash) || value.is_a?(Array)
             raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected Hash or Array"
           end
-          @hadoop.set(JSON.generate(value))
+          super(JSON.generate(value))
         end
 
         def ruby
-          JSON.parse(hadoop.to_s)
+          JSON.parse(super())
         end
       end
     end

--- a/lib/humboldt/type_converters.rb
+++ b/lib/humboldt/type_converters.rb
@@ -5,31 +5,6 @@ module Humboldt
     class Binary
       HADOOP = ::Hadoop::Io::BytesWritable
       RUBY = ::String
-
-      attr_reader :hadoop
-
-      def hadoop=(value)
-        unless value.is_a?(HADOOP)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{HADOOP}"
-        end
-        @hadoop = value
-      end
-
-      def initialize
-        @hadoop = HADOOP.new
-      end
-
-      def ruby
-        String.from_java_bytes(@hadoop.bytes).byteslice(0, @hadoop.length)
-      end
-
-      def ruby=(value)
-        unless value.is_a?(RUBY)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{RUBY}"
-        end
-
-        @hadoop.set(value.to_java_bytes, 0, value.bytesize)
-      end
     end
 
     begin
@@ -53,35 +28,6 @@ module Humboldt
     class Text
       HADOOP = ::Hadoop::Io::Text
       RUBY = ::String
-
-      attr_reader :hadoop
-
-      def hadoop=(value)
-        unless value.is_a?(HADOOP)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{HADOOP}"
-        end
-        @hadoop = value
-      end
-
-      def initialize
-        @hadoop = HADOOP.new
-      end
-
-      def ruby
-        String.from_java_bytes(@hadoop.bytes).byteslice(0, @hadoop.length).force_encoding(Encoding::UTF_8)
-      end
-
-      def ruby=(value)
-        unless value.is_a?(RUBY)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{RUBY}"
-        end
-
-        if value.encoding == Encoding::UTF_8
-          @hadoop.set(value.to_java_bytes, 0, value.bytesize)
-        else
-          @hadoop.set(value)
-        end
-      end
     end
 
     begin
@@ -104,56 +50,11 @@ module Humboldt
     class Long
       HADOOP = ::Hadoop::Io::LongWritable
       RUBY = ::Integer
-
-      attr_reader :hadoop
-
-      def hadoop=(value)
-        unless value.is_a?(HADOOP)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{HADOOP}"
-        end
-        @hadoop = value
-      end
-
-      def initialize
-        @hadoop = HADOOP.new
-      end
-
-      def ruby
-        @hadoop.get
-      end
-
-      def ruby=(value)
-        unless value.is_a?(Integer)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{RUBY}"
-        end
-
-        @hadoop.set value
-      end
     end
 
     class None
       HADOOP = ::Hadoop::Io::NullWritable
       RUBY = ::NilClass
-
-      def hadoop
-        HADOOP.get
-      end
-
-      def hadoop=(value)
-        unless value.is_a?(HADOOP)
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{HADOOP}"
-        end
-      end
-
-      def ruby
-        nil
-      end
-
-      def ruby=(value)
-        unless value.nil?
-          raise ArgumentError, "Hadoop type mismatch, was #{value.class}, expected #{RUBY}"
-        end
-      end
     end
 
     TYPE_CONVERTER_CLASS_CACHE = Hash.new { |h,k| h[k] = const_get(k.to_s.capitalize) }


### PR DESCRIPTION
This improves performance primarily for the binary and text formats, as this avoids the creation of proxies for the byte arrays.

So far, I've opted to keep the old Ruby-implementations, but perhaps this only confuses/complicates things. Personally, I think it would be best either to remove them, or to write tests for both implementations, and could not quite make up my mind. As is, only the Java-implementations are tested.