### PR TITLE
Updated aws-sdk dependency to include support for EMR service_role parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,16 @@ PATH
   remote: .
   specs:
     humboldt (1.0.3-java)
-      aws-sdk (>= 1.16.0, < 1.33.0)
+      aws-sdk-v1 (>= 1.44.0)
       rubydoop (~> 1.1.2)
       thor
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-sdk (1.32.0)
+    aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-      uuidtools (~> 2.1)
     builder (3.1.4)
     coderay (1.0.7)
     diff-lcs (1.1.3)
@@ -21,10 +20,14 @@ GEM
       httpclient
       sinatra
     httpclient (2.3.0.1)
-    json (1.8.1-java)
+    json (1.8.3-java)
     method_source (0.8)
     msgpack-jruby (1.3.0-java)
-    nokogiri (1.6.2.1-java)
+    nokogiri (1.6.6.2-java)
+    pry (0.9.10)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.3.1)
     pry (0.9.10-java)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -51,10 +54,10 @@ GEM
     spoon (0.0.1)
     thor (0.19.1)
     tilt (1.3.3)
-    uuidtools (2.1.4)
 
 PLATFORMS
   java
+  ruby
 
 DEPENDENCIES
   geminabox

--- a/humboldt.gemspec
+++ b/humboldt.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'thor'
   s.add_dependency 'rubydoop', '~> 1.1.2'
-  s.add_dependency 'aws-sdk', '>= 1.16.0', '< 1.33.0'
+  s.add_dependency 'aws-sdk-v1', '>= 1.44.0'
 
   s.files         = Dir['lib/**/*.{rb,jar}'] + Dir['bin/*'] + Dir['config/**/*']
   s.executables  = %w[humboldt]


### PR DESCRIPTION
In order to keep running EMR jobs after July 1st, jobs need to have a IAM service role. Support for this parameter was added in `aws-sdk` 1.44, so this pull request updates the dependency.