### PR TITLE
Use mapreduce.* properties instead of mapred.*

### DIFF
--- a/lib/ext/rubydoop.rb
+++ b/lib/ext/rubydoop.rb
@@ -33,16 +33,16 @@ module Rubydoop
 
     def enable_compression!
       unless local_mode?
-        set 'mapred.compress.map.output', true
-        set 'mapred.output.compress', true
-        set 'mapred.map.output.compression.codec', 'org.apache.hadoop.io.compress.GzipCodec'
-        set 'mapred.output.compression.codec', 'org.apache.hadoop.io.compress.GzipCodec'
-        set 'mapred.output.compression.type', 'BLOCK'
+        set 'mapreduce.map.output.compress', true
+        set 'mapreduce.output.fileoutputformat.compress', true
+        set 'mapreduce.map.output.compress.codec', 'org.apache.hadoop.io.compress.GzipCodec'
+        set 'mapreduce.output.fileoutputformat.compress.codec', 'org.apache.hadoop.io.compress.GzipCodec'
+        set 'mapreduce.output.fileoutputformat.compress.type', 'BLOCK'
       end
     end
 
     def local_mode?
-      @job.configuration.get('mapred.job.tracker') == 'local'
+      @job.configuration.get('mapreduce.jobtracker.address') == 'local'
     end
 
     def cache_file(file, options = {})

--- a/lib/ext/rubydoop.rb
+++ b/lib/ext/rubydoop.rb
@@ -33,16 +33,29 @@ module Rubydoop
 
     def enable_compression!
       unless local_mode?
-        set 'mapreduce.map.output.compress', true
-        set 'mapreduce.output.fileoutputformat.compress', true
-        set 'mapreduce.map.output.compress.codec', 'org.apache.hadoop.io.compress.GzipCodec'
-        set 'mapreduce.output.fileoutputformat.compress.codec', 'org.apache.hadoop.io.compress.GzipCodec'
-        set 'mapreduce.output.fileoutputformat.compress.type', 'BLOCK'
+        if framework == :mapreduce
+          set 'mapreduce.map.output.compress', true
+          set 'mapreduce.output.fileoutputformat.compress', true
+          set 'mapreduce.map.output.compress.codec', 'org.apache.hadoop.io.compress.GzipCodec'
+          set 'mapreduce.output.fileoutputformat.compress.codec', 'org.apache.hadoop.io.compress.GzipCodec'
+          set 'mapreduce.output.fileoutputformat.compress.type', 'BLOCK'
+        else
+          set 'mapred.compress.map.output', true
+          set 'mapred.output.compress', true
+          set 'mapred.map.output.compression.codec', 'org.apache.hadoop.io.compress.GzipCodec'
+          set 'mapred.output.compression.codec', 'org.apache.hadoop.io.compress.GzipCodec'
+          set 'mapred.output.compression.type', 'BLOCK'
+        end
       end
     end
 
+    def framework
+      @framework ||= @job.configuration.get('mapreduce.framework.name') ? :mapreduce : :mapred
+    end
+
     def local_mode?
-      @job.configuration.get('mapreduce.jobtracker.address') == 'local'
+      property = framework == :mapreduce ? 'mapreduce.framework.name' : 'mapred.job.tracker'
+      @job.configuration.get(property) == 'local'
     end
 
     def cache_file(file, options = {})


### PR DESCRIPTION
When running on anything remotely modern we get deprecation warnings about using mapred.* properties. I don't think there's any danger of using mapreduce.* properties since Rubydoop uses the org.apache.hadoop.mapreduce packages and isn't even compatible with Hadoop versions that only support org.apache.hadoop.mapred.