### PR TITLE
Add humbold.BinaryComparator for using with Hadoop's BinaryPartitioner

### DIFF
--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -8,6 +8,7 @@ import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.BinaryComparable;
 import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.mapreduce.Job;
 
 
@@ -18,6 +19,10 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
   private Configuration conf;
   private int leftOffset;
   private int rightOffset;
+
+  public BinaryComparator() {
+    super(BytesWritable.class);
+  }
 
   public static void setOffsets(Configuration conf, int left, int right) {
     conf.setInt(LEFT_OFFSET_PROPERTY_NAME, left);

--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -9,7 +9,6 @@ import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.MRJobConfig;
 
 public class BinaryComparator<K, V> extends WritableComparator implements Configurable {
   public static String LEFT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.left.offset";
@@ -45,7 +44,11 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
     this.conf = conf;
     this.leftOffset = conf.getInt(LEFT_OFFSET_PROPERTY_NAME, 0);
     this.rightOffset = conf.getInt(RIGHT_OFFSET_PROPERTY_NAME, -1);
-    this.keyClass = conf.getClass(MRJobConfig.MAP_OUTPUT_KEY_CLASS, BytesWritable.class, BinaryComparable.class);
+    if (conf.get("mapreduce.map.output.key.class") == null) {
+      this.keyClass = conf.getClass("mapred.mapoutput.key.class", BytesWritable.class, BinaryComparable.class);
+    } else {
+      this.keyClass = conf.getClass("mapreduce.map.output.key.class", BytesWritable.class, BinaryComparable.class);
+    }
   }
 
   public Configuration getConf() {

--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -46,7 +46,7 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
     this.conf = conf;
     this.leftOffset = conf.getInt(LEFT_OFFSET_PROPERTY_NAME, 0);
     this.rightOffset = conf.getInt(RIGHT_OFFSET_PROPERTY_NAME, -1);
-    this.keyClass = conf.getClass(MRJobConfig.MAP_OUTPUT_VALUE_CLASS, BytesWritable.class, BinaryComparable.class);
+    this.keyClass = conf.getClass(MRJobConfig.MAP_OUTPUT_KEY_CLASS, BytesWritable.class, BinaryComparable.class);
   }
 
   public Configuration getConf() {

--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -1,7 +1,5 @@
 package humboldt;
 
-import java.util.Arrays;
-
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.WritableComparator;
@@ -9,7 +7,9 @@ import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.BinaryComparable;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 
 
 public class BinaryComparator<K, V> extends WritableComparator implements Configurable {
@@ -17,11 +17,16 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
   public static String RIGHT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.right.offset";
 
   private Configuration conf;
+  private Class<? extends BinaryComparable> keyClass;
   private int leftOffset;
   private int rightOffset;
 
   public BinaryComparator() {
-    super(BytesWritable.class);
+    super(null);
+  }
+
+  public BinaryComparator(Class<? extends WritableComparable> keyClass) {
+    super(keyClass);
   }
 
   public static void setOffsets(Configuration conf, int left, int right) {
@@ -39,8 +44,9 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
 
   public void setConf(Configuration conf) {
     this.conf = conf;
-    leftOffset = conf.getInt(LEFT_OFFSET_PROPERTY_NAME, 0);
-    rightOffset = conf.getInt(RIGHT_OFFSET_PROPERTY_NAME, -1);
+    this.leftOffset = conf.getInt(LEFT_OFFSET_PROPERTY_NAME, 0);
+    this.rightOffset = conf.getInt(RIGHT_OFFSET_PROPERTY_NAME, -1);
+    this.keyClass = conf.getClass(MRJobConfig.MAP_OUTPUT_VALUE_CLASS, BytesWritable.class, BinaryComparable.class);
   }
 
   public Configuration getConf() {
@@ -50,15 +56,29 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
   public int compare(WritableComparable w1, WritableComparable w2) {
     BinaryComparable bc1 = (BinaryComparable) w1;
     BinaryComparable bc2 = (BinaryComparable) w2;
-    return compare(bc1.getBytes(), 0, bc1.getLength(),
-                   bc2.getBytes(), 0, bc2.getLength());
+    return compareRawBytes(bc1.getBytes(), 0, bc1.getLength(),
+                           bc2.getBytes(), 0, bc2.getLength());
   }
 
   public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
-    int b1LeftIndex = (leftOffset + l1) % l1;
-    int b1RightIndex = (rightOffset + l1) % l1;
-    int b2LeftIndex = (leftOffset + l2) % l2;
-    int b2RightIndex = (rightOffset + l2) % l2;
+    int n1 = 0;
+    int n2 = 0;
+    if (keyClass == BytesWritable.class) {
+      n1 = 4;
+      n2 = 4;
+    } else if (keyClass == Text.class) {
+      n1 = WritableUtils.decodeVIntSize(b1[s1]);
+      n2 = WritableUtils.decodeVIntSize(b2[s2]);
+    }
+    return compareRawBytes(b1, s1 + n1, l1 - n1,
+                           b2, s2 + n2, l2 - n2);
+  }
+
+  public int compareRawBytes(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+    int b1LeftIndex = (leftOffset + s1 + l1) % l1;
+    int b1RightIndex = (rightOffset + s1 + l1) % l1;
+    int b2LeftIndex = (leftOffset + s2 + l2) % l2;
+    int b2RightIndex = (rightOffset + s2 + l2) % l2;
     return WritableComparator.compareBytes(b1, b1LeftIndex, b1RightIndex - b1LeftIndex + 1,
                                            b2, b2LeftIndex, b2RightIndex - b2LeftIndex + 1);
   }

--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -11,7 +11,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 
-
 public class BinaryComparator<K, V> extends WritableComparator implements Configurable {
   public static String LEFT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.left.offset";
   public static String RIGHT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.right.offset";
@@ -75,10 +74,10 @@ public class BinaryComparator<K, V> extends WritableComparator implements Config
   }
 
   public int compareRawBytes(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
-    int b1LeftIndex = (leftOffset + s1 + l1) % l1;
-    int b1RightIndex = (rightOffset + s1 + l1) % l1;
-    int b2LeftIndex = (leftOffset + s2 + l2) % l2;
-    int b2RightIndex = (rightOffset + s2 + l2) % l2;
+    int b1LeftIndex = s1 + ((leftOffset + l1) % l1);
+    int b1RightIndex = s1 + ((rightOffset + l1) % l1);
+    int b2LeftIndex = s2 + ((leftOffset + l2) % l2);
+    int b2RightIndex = s2 + ((rightOffset + l2) % l2);
     return WritableComparator.compareBytes(b1, b1LeftIndex, b1RightIndex - b1LeftIndex + 1,
                                            b2, b2LeftIndex, b2RightIndex - b2LeftIndex + 1);
   }

--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -8,7 +8,6 @@ import org.apache.hadoop.io.BinaryComparable;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapreduce.Job;
 
 public class BinaryComparator<K, V> extends WritableComparator implements Configurable {
   public static String LEFT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.left.offset";

--- a/ext/src/humboldt/BinaryComparator.java
+++ b/ext/src/humboldt/BinaryComparator.java
@@ -1,0 +1,60 @@
+package humboldt;
+
+import java.util.Arrays;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.WritableComparator;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.io.BinaryComparable;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.hadoop.mapreduce.Job;
+
+
+public class BinaryComparator<K, V> extends WritableComparator implements Configurable {
+  public static String LEFT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.left.offset";
+  public static String RIGHT_OFFSET_PROPERTY_NAME = "humboldt.binarycomparator.right.offset";
+
+  private Configuration conf;
+  private int leftOffset;
+  private int rightOffset;
+
+  public static void setOffsets(Configuration conf, int left, int right) {
+    conf.setInt(LEFT_OFFSET_PROPERTY_NAME, left);
+    conf.setInt(RIGHT_OFFSET_PROPERTY_NAME, right);
+  }
+
+  public static void setLeftOffset(Configuration conf, int offset) {
+    conf.setInt(LEFT_OFFSET_PROPERTY_NAME, offset);
+  }
+
+  public static void setRightOffset(Configuration conf, int offset) {
+    conf.setInt(RIGHT_OFFSET_PROPERTY_NAME, offset);
+  }
+
+  public void setConf(Configuration conf) {
+    this.conf = conf;
+    leftOffset = conf.getInt(LEFT_OFFSET_PROPERTY_NAME, 0);
+    rightOffset = conf.getInt(RIGHT_OFFSET_PROPERTY_NAME, -1);
+  }
+
+  public Configuration getConf() {
+    return conf;
+  }
+
+  public int compare(WritableComparable w1, WritableComparable w2) {
+    BinaryComparable bc1 = (BinaryComparable) w1;
+    BinaryComparable bc2 = (BinaryComparable) w2;
+    return compare(bc1.getBytes(), 0, bc1.getLength(),
+                   bc2.getBytes(), 0, bc2.getLength());
+  }
+
+  public int compare(byte[] b1, int s1, int l1, byte[] b2, int s2, int l2) {
+    int b1LeftIndex = (leftOffset + l1) % l1;
+    int b1RightIndex = (rightOffset + l1) % l1;
+    int b2LeftIndex = (leftOffset + l2) % l2;
+    int b2RightIndex = (rightOffset + l2) % l2;
+    return WritableComparator.compareBytes(b1, b1LeftIndex, b1RightIndex - b1LeftIndex + 1,
+                                           b2, b2LeftIndex, b2RightIndex - b2LeftIndex + 1);
+  }
+}

--- a/lib/ext/hadoop.rb
+++ b/lib/ext/hadoop.rb
@@ -7,4 +7,11 @@ module Hadoop
   module Conf
     include_package 'org.apache.hadoop.conf'
   end
+  module Mapreduce
+    module Lib
+      module Partition
+        include_package 'org.apache.hadoop.mapreduce.lib.partition'
+      end
+    end
+  end
 end

--- a/lib/ext/rubydoop.rb
+++ b/lib/ext/rubydoop.rb
@@ -69,5 +69,58 @@ module Rubydoop
         Hadoop::FileCache::DistributedCache.add_cache_file(uri, @job.configuration)
       end
     end
+
+    # Configures the job for secondary sort on the specified slice of the mapper
+    # output key.
+    #
+    # Hadoop comes with a partitioner that can partition the map output based
+    # on a slice of the map output key. Humboldt ships with a comparator that
+    # uses the same configuration. Together they can be used to implement
+    # secondary sort.
+    #
+    # Secondary sort is a mapreduce pattern where you emit a key, but partition
+    # and group only on a subset of that key. This has the result that each
+    # reduce invocation will see values grouped by the subset, but ordered by
+    # the whole key. It is used, among other things, to efficiently count
+    # distinct values.
+    #
+    # Say you want to count the number of distinct visitors to a site. Your
+    # input is pairs of site and visitor IDs. The naïve implementation is to
+    # emit the site as key and the visitor ID as value and then, in the reducer,
+    # collect all IDs in a set, and emit the site and the size of the set of IDs.
+    # This is very memory inefficient, and impractical. For any interesting
+    # amount of data you will not be able to keep all the visitor IDs in memory.
+    #
+    # What you do, instead, is to concatenate the site and visitor ID and emit
+    # that as key, and the visitor ID as value. It might seem wasteful to emit
+    # the visitor ID twice, but it's necessary since Hadoop will only give you
+    # the key for the first value in each group.
+    #
+    # You then instruct Hadoop to partition and group on just the site part of
+    # the key. Hadoop will still sort the values by their full key, so within
+    # each group the values will be sorted by visitor ID. In the reducer it's
+    # now trivial to loop over the values and just increment a counter each time
+    # the visitor ID changes.
+    #
+    # You configure which part of the key to partition and group by specifying
+    # the start and end _indexes_. The reason why they are indexes and not a
+    # start index and a length, like Ruby's `String#slice`, is that you also can
+    # use negative indexes to count from the end. Negative indexes are useful
+    # for example when you don't know how wide the part of the key that you want
+    # use is. In the example above if you use the domain to identify sites these
+    # can be of different length. If your visitor IDs are 20 characters you can
+    # use 0 and -20 as your indexes.
+    #
+    # @param [Fixnum] start_index The first index of the slice, negative numbers
+    #   are counted from the end
+    # @param [Fixnum] end_index The last index of the slice, negative numbers
+    #   are counted from the end
+    # @see http://hadoop.apache.org/docs/r2.7.1/api/org/apache/hadoop/mapreduce/lib/partition/BinaryPartitioner.html Hadoop's BinaryPartitioner
+    def secondary_sort(start_index, end_index)
+      @job.set_partitioner_class(Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner)
+      Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner.set_offsets(@job.configuration, start_index, end_index)
+      @job.set_grouping_comparator_class(Humboldt::JavaLib::BinaryComparator)
+      Humboldt::JavaLib::BinaryComparator.set_offsets(@job.configuration, start_index, end_index)
+    end
   end
 end

--- a/spec/fixtures/test_project/.gitignore
+++ b/spec/fixtures/test_project/.gitignore
@@ -3,6 +3,7 @@
 /ext/dist
 /data/test_project
 /data/another_job_config
+/data/secondary_sort_test
 /data/log
 /important.doc
 /another_file

--- a/spec/fixtures/test_project/lib/secondary_sort_test.rb
+++ b/spec/fixtures/test_project/lib/secondary_sort_test.rb
@@ -1,0 +1,50 @@
+# encoding: utf-8
+
+require 'humboldt'
+
+module SecondarySortTest
+  USER_ID_LENGTH = 5
+
+  class Mapper < Humboldt::Mapper
+    input :long, :text
+    output :text, :text
+
+    map do |_, value|
+      site, user_id = value.split(',')
+      emit("#{site}#{user_id}", user_id)
+    end
+  end
+
+  class Reducer < Humboldt::Reducer
+    input :text, :text
+    output :text, :text
+
+    reduce do |key, values|
+      count = 0
+      site = key[0, key.bytesize - USER_ID_LENGTH]
+      last_value = nil
+      values.each do |value|
+        count += 1 if value != last_value
+        last_value = value
+      end
+      emit(site, count.to_s)
+    end
+  end
+end
+
+Rubydoop.configure do |input_path, output_path|
+  job 'test secondary sort' do
+    input input_path
+    output output_path
+
+    mapper SecondarySortTest::Mapper
+    reducer SecondarySortTest::Reducer
+
+    raw do |job|
+      job.set_partitioner_class(Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner)
+      Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner.set_offsets(job.configuration, -SecondarySortTest::USER_ID_LENGTH, -1)
+      job.set_grouping_comparator_class(Humboldt::JavaLib::BinaryComparator)
+      Humboldt::JavaLib::BinaryComparator.set_offsets(job.configuration, -SecondarySortTest::USER_ID_LENGTH, -1)
+    end
+  end
+end

--- a/spec/fixtures/test_project/lib/secondary_sort_test.rb
+++ b/spec/fixtures/test_project/lib/secondary_sort_test.rb
@@ -40,11 +40,6 @@ Rubydoop.configure do |input_path, output_path|
     mapper SecondarySortTest::Mapper
     reducer SecondarySortTest::Reducer
 
-    raw do |job|
-      job.set_partitioner_class(Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner)
-      Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner.set_offsets(job.configuration, -SecondarySortTest::USER_ID_LENGTH, -1)
-      job.set_grouping_comparator_class(Humboldt::JavaLib::BinaryComparator)
-      Humboldt::JavaLib::BinaryComparator.set_offsets(job.configuration, -SecondarySortTest::USER_ID_LENGTH, -1)
-    end
+    secondary_sort 0, -SecondarySortTest::USER_ID_LENGTH
   end
 end

--- a/spec/humboldt/binary_comparator_spec.rb
+++ b/spec/humboldt/binary_comparator_spec.rb
@@ -22,8 +22,47 @@ module Humboldt
         ]
       end
 
+      let :left_offset do
+        0
+      end
+
+      let :right_offset do
+        -1
+      end
+
+      def prefix_size(w)
+        case w
+        when Hadoop::Io::BytesWritable
+          4
+        when Hadoop::Io::Text
+          Hadoop::Io::WritableUtils.decodeVIntSize(writable_to_bytes(w)[0])
+        else
+          raise 'Not supported'
+        end
+      end
+
+      def writable_to_bytes(w)
+        Hadoop::Io::WritableUtils.to_byte_array(w)
+      end
+
+      def should_compare(k1, k2, assertion)
+        compare_writables(k1, k2).should(assertion)
+        compare_bytes(k1, k2).should(assertion)
+      end
+
+      def compare_writables(k1, k2)
+        comparator.compare(k1, k2)
+      end
+
+      def compare_bytes(k1, k2)
+        b1 = writable_to_bytes(k1)
+        b2 = writable_to_bytes(k2)
+        comparator.compare(b1, 0, k1.length + prefix_size(k1), b2, 0, k2.length + prefix_size(k1))
+      end
+
       before do
         described_class.set_offsets(conf, left_offset, right_offset)
+        conf.set(Hadoop::Mapreduce::MRJobConfig::MAP_OUTPUT_KEY_CLASS, keys.first.java_class.name)
         comparator.set_conf(conf)
       end
 
@@ -37,27 +76,27 @@ module Humboldt
         end
 
         it 'returns 0 when comparing a writable to itself' do
-          comparator.compare(keys[0], keys[0]).should eq(0)
+          should_compare(keys[0], keys[0], eq(0))
         end
 
         it 'returns -1 when the first argument is lesser than the second' do
-          comparator.compare(keys[0], keys[3]).should eq(-1)
+          should_compare(keys[0], keys[3], eq(-1))
         end
 
         it 'returns 1 when the first argument is greater than the second' do
-          comparator.compare(keys[3], keys[0]).should eq(1)
+          should_compare(keys[3], keys[0], eq(1))
         end
 
         it 'returns 0 when the specified slice of the arguments are equal' do
-          comparator.compare(keys[0], keys[1]).should eq(0)
+          should_compare(keys[0], keys[1], eq(0))
         end
 
         it 'returns -1 when the specified slice of the first argument is lesser than the same slice of second' do
-          comparator.compare(keys[0], keys[2]).should eq(-1)
+          should_compare(keys[0], keys[2], eq(-1))
         end
 
         it 'returns 1 when the specified slice of the first argument is greater than the same slice of the second' do
-          comparator.compare(keys[2], keys[0]).should eq(1)
+          should_compare(keys[2], keys[0], eq(1))
         end
       end
 
@@ -71,27 +110,27 @@ module Humboldt
         end
 
         it 'returns 0 when comparing a writable to itself' do
-          comparator.compare(keys[0], keys[0]).should eq(0)
+          should_compare(keys[0], keys[0], eq(0))
         end
 
         it 'returns -1 when the first argument is lesser than the second' do
-          comparator.compare(keys[0], keys[2]).should eq(-1)
+          should_compare(keys[0], keys[2], eq(-1))
         end
 
         it 'returns 1 when the first argument is greater than the second' do
-          comparator.compare(keys[2], keys[0]).should eq(1)
+          should_compare(keys[2], keys[0], eq(1))
         end
 
         it 'returns 0 when the specified slice of the arguments are equal' do
-          comparator.compare(keys[0], keys[3]).should eq(0)
+          should_compare(keys[0], keys[3], eq(0))
         end
 
         it 'returns -1 when the specified slice of the first argument is lesser than the same slice of second' do
-          comparator.compare(keys[0], keys[2]).should eq(-1)
+          should_compare(keys[0], keys[2], eq(-1))
         end
 
         it 'returns 1 when the specified slice of the first argument is greater than the same slice of the second' do
-          comparator.compare(keys[2], keys[0]).should eq(1)
+          should_compare(keys[2], keys[0], eq(1))
         end
       end
 
@@ -114,17 +153,34 @@ module Humboldt
         end
 
         it 'returns 0 when comparing a writable to itself' do
-          comparator.compare(keys[0], keys[0]).should eq(0)
+          should_compare(keys[0], keys[0], eq(0))
         end
 
         it 'counts the offsets from the end of the byte arrays' do
-          sorted_keys = keys.sort { |k1, k2| comparator.compare(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
+          sorted_keys = keys.sort { |k1, k2| compare_writables(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
           sorted_keys.should eq(%w[
             xxxx1xxx
             xx2xxx
             xxx3xxx
             x4xxx
           ])
+          sorted_keys = keys.sort { |k1, k2| compare_bytes(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
+          sorted_keys.should eq(%w[
+            xxxx1xxx
+            xx2xxx
+            xxx3xxx
+            x4xxx
+          ])
+        end
+      end
+
+      context 'when the writable does not align with the start of the byte array' do
+        it 'correctly accounts for the offset' do
+          b1 = writable_to_bytes(Hadoop::Io::BytesWritable.new('foobar'.to_java_bytes))
+          bytes = String.from_java_bytes(b1)
+          bytes.prepend("\xff")
+          b2 = bytes.to_java_bytes
+          comparator.compare(b1, 0, 10, b2, 1, 10).should eq(0)
         end
       end
 
@@ -153,11 +209,13 @@ module Humboldt
         end
 
         it 'returns 0 when comparing a Text to itself' do
-          comparator.compare(keys[0], keys[0]).should eq(0)
+          should_compare(keys[0], keys[0], eq(0))
         end
 
         it 'counts the offsets from the end of the byte arrays' do
-          sorted_keys = keys.sort { |k1, k2| comparator.compare(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
+          sorted_keys = keys.sort { |k1, k2| compare_writables(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
+          sorted_keys.should eq(strings.values_at(3, 1, 0, 2))
+          sorted_keys = keys.sort { |k1, k2| compare_bytes(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
           sorted_keys.should eq(strings.values_at(3, 1, 0, 2))
         end
       end
@@ -174,7 +232,7 @@ module Humboldt
         it 'raises an error' do
           i1 = Hadoop::Io::IntWritable.new(3)
           i2 = Hadoop::Io::IntWritable.new(4)
-          expect { comparator.compare(i1, i2) }.to raise_error(java.lang.ClassCastException)
+          expect { compare_writables(i1, i2) }.to raise_error(java.lang.ClassCastException)
         end
       end
     end

--- a/spec/humboldt/binary_comparator_spec.rb
+++ b/spec/humboldt/binary_comparator_spec.rb
@@ -161,6 +161,22 @@ module Humboldt
           sorted_keys.should eq(strings.values_at(3, 1, 0, 2))
         end
       end
+
+      context 'when attempting to compare something that is not BinaryComparable' do
+        let :left_offset do
+          0
+        end
+
+        let :right_offset do
+          4
+        end
+
+        it 'raises an error' do
+          i1 = Hadoop::Io::IntWritable.new(3)
+          i2 = Hadoop::Io::IntWritable.new(4)
+          expect { comparator.compare(i1, i2) }.to raise_error(java.lang.ClassCastException)
+        end
+      end
     end
   end
 end

--- a/spec/humboldt/binary_comparator_spec.rb
+++ b/spec/humboldt/binary_comparator_spec.rb
@@ -1,0 +1,167 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Humboldt
+  module JavaLib
+    describe BinaryComparator do
+      let :comparator do
+        described_class.new
+      end
+
+      let :conf do
+        Hadoop::Conf::Configuration.new
+      end
+
+      let :keys do
+        [
+          Hadoop::Io::BytesWritable.new("01234".to_java_bytes),
+          Hadoop::Io::BytesWritable.new("01235".to_java_bytes),
+          Hadoop::Io::BytesWritable.new("01244".to_java_bytes),
+          Hadoop::Io::BytesWritable.new("11235".to_java_bytes),
+        ]
+      end
+
+      before do
+        described_class.set_offsets(conf, left_offset, right_offset)
+        comparator.set_conf(conf)
+      end
+
+      context 'when limiting the comparison to a prefix' do
+        let :left_offset do
+          0
+        end
+
+        let :right_offset do
+          3
+        end
+
+        it 'returns 0 when comparing a writable to itself' do
+          comparator.compare(keys[0], keys[0]).should eq(0)
+        end
+
+        it 'returns -1 when the first argument is lesser than the second' do
+          comparator.compare(keys[0], keys[3]).should eq(-1)
+        end
+
+        it 'returns 1 when the first argument is greater than the second' do
+          comparator.compare(keys[3], keys[0]).should eq(1)
+        end
+
+        it 'returns 0 when the specified slice of the arguments are equal' do
+          comparator.compare(keys[0], keys[1]).should eq(0)
+        end
+
+        it 'returns -1 when the specified slice of the first argument is lesser than the same slice of second' do
+          comparator.compare(keys[0], keys[2]).should eq(-1)
+        end
+
+        it 'returns 1 when the specified slice of the first argument is greater than the same slice of the second' do
+          comparator.compare(keys[2], keys[0]).should eq(1)
+        end
+      end
+
+      context 'when comparing a slice in the middle' do
+        let :left_offset do
+          1
+        end
+
+        let :right_offset do
+          3
+        end
+
+        it 'returns 0 when comparing a writable to itself' do
+          comparator.compare(keys[0], keys[0]).should eq(0)
+        end
+
+        it 'returns -1 when the first argument is lesser than the second' do
+          comparator.compare(keys[0], keys[2]).should eq(-1)
+        end
+
+        it 'returns 1 when the first argument is greater than the second' do
+          comparator.compare(keys[2], keys[0]).should eq(1)
+        end
+
+        it 'returns 0 when the specified slice of the arguments are equal' do
+          comparator.compare(keys[0], keys[3]).should eq(0)
+        end
+
+        it 'returns -1 when the specified slice of the first argument is lesser than the same slice of second' do
+          comparator.compare(keys[0], keys[2]).should eq(-1)
+        end
+
+        it 'returns 1 when the specified slice of the first argument is greater than the same slice of the second' do
+          comparator.compare(keys[2], keys[0]).should eq(1)
+        end
+      end
+
+      context 'with negative offsets' do
+        let :keys do
+          [
+            Hadoop::Io::BytesWritable.new("x4xxx".to_java_bytes),
+            Hadoop::Io::BytesWritable.new("xx2xxx".to_java_bytes),
+            Hadoop::Io::BytesWritable.new("xxx3xxx".to_java_bytes),
+            Hadoop::Io::BytesWritable.new("xxxx1xxx".to_java_bytes),
+          ]
+        end
+
+        let :left_offset do
+          -4
+        end
+
+        let :right_offset do
+          -3
+        end
+
+        it 'returns 0 when comparing a writable to itself' do
+          comparator.compare(keys[0], keys[0]).should eq(0)
+        end
+
+        it 'counts the offsets from the end of the byte arrays' do
+          sorted_keys = keys.sort { |k1, k2| comparator.compare(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
+          sorted_keys.should eq(%w[
+            xxxx1xxx
+            xx2xxx
+            xxx3xxx
+            x4xxx
+          ])
+        end
+      end
+
+      context 'when comparing Text' do
+        let :strings do
+          [
+            ('x' * 3) << "3xxx",
+            ('x' * 400) << "2xxx",
+            ('x' * 63) << "4xxx",
+            ('x' * 14) << "1xxx",
+          ]
+        end
+
+        let :keys do
+          strings.map do |s|
+            Hadoop::Io::Text.new(s.to_java_bytes)
+          end
+        end
+
+        let :left_offset do
+          -4
+        end
+
+        let :right_offset do
+          -3
+        end
+
+        it 'returns 0 when comparing a Text to itself' do
+          comparator.compare(keys[0], keys[0]).should eq(0)
+        end
+
+        it 'counts the offsets from the end of the byte arrays' do
+          sorted_keys = keys.sort { |k1, k2| comparator.compare(k1, k2) }.map { |k| String.from_java_bytes(k.bytes) }
+          sorted_keys.should eq(strings.values_at(3, 1, 0, 2))
+        end
+      end
+    end
+  end
+end
+

--- a/spec/humboldt/binary_comparator_spec.rb
+++ b/spec/humboldt/binary_comparator_spec.rb
@@ -62,7 +62,8 @@ module Humboldt
 
       before do
         described_class.set_offsets(conf, left_offset, right_offset)
-        conf.set(Hadoop::Mapreduce::MRJobConfig::MAP_OUTPUT_KEY_CLASS, keys.first.java_class.name)
+        conf.set('mapred.mapoutput.key.class', keys.first.java_class.name)
+        conf.set('mapreduce.map.output.key.class', keys.first.java_class.name)
         comparator.set_conf(conf)
       end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -25,7 +25,7 @@ describe 'Packaging and running a project' do
     FileUtils.rm_rf File.join(test_project_dir, 'another_file')
     FileUtils.rm_rf File.join(test_project_dir, 'Gemfile.lock')
 
-    isolated_run(test_project_dir, "gem install ../../../pkg/*.gem")
+    isolated_run(test_project_dir, "gem install ../../../pkg/*#{Humboldt::VERSION}*.gem")
     isolated_run(test_project_dir, "bundle install --retry 3")
     isolated_run(test_project_dir, "bundle exec humboldt package")
   end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -111,4 +111,35 @@ describe 'Packaging and running a project' do
       expect(File.directory?('data/another_job_config/output')).to be_true
     end
   end
+
+  context 'Using secondary sort' do
+    VISITS = [
+      ['acme.net', 'USER1'],
+      ['acme.net', 'USER2'],
+      ['acme.net', 'USER2'],
+      ['acme.net', 'USER3'],
+      ['evilcorp.com', 'USER1'],
+      ['evilcorp.com', 'USER1'],
+      ['example.com', 'USER1'],
+      ['example.com', 'USER2'],
+    ].freeze
+
+    before :all do
+      input_path = File.join(test_project_dir, 'data/secondary_sort_test/visits.csv')
+      FileUtils.mkdir_p(File.dirname(input_path))
+      File.open(input_path, 'w') do |io|
+        VISITS.shuffle.each do |site, user_id|
+          io.puts("#{site},#{user_id}")
+        end
+      end
+      isolated_run(test_project_dir, "bundle exec humboldt run-local --job-config=secondary_sort_test --cleanup-before --skip-package --data-path='' --input='#{input_path}' 2>&1 | tee data/log")
+    end
+
+    it 'partitions and groups on part of the map output key' do
+      pairs = File.readlines('data/secondary_sort_test/output/part-r-00000').map { |line| line.chomp.split("\t") }
+      pairs.should include(%w[acme.net 3])
+      pairs.should include(%w[evilcorp.com 1])
+      pairs.should include(%w[example.com 2])
+    end
+  end
 end


### PR DESCRIPTION
This replaces Humboldt::BinaryPrefixPartitioner and friends, if you can live with having to write a more cryptic job configuration. The idea is that Hadoop's BinaryPartitioner is both more efficient and more versatile than what's currently in Humboldt, but Hadoop is missing a comparator that works with the same offset configuration.

For secondary sort instead of

```ruby
partitioner(MyPartitionerBasedOnBinaryPrefixPartitioner)
grouping_comparator(MyComparatorBasedOnBinaryPrefixComparator)
```

you'll have to do (assuming the classes in the example above are configured to look at the first 12 bytes)

```ruby
raw do |job|
  job.set_partitioner_class(Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner)
  Hadoop::Mapreduce::Lib::Partition::BinaryPartitioner.set_offsets(job.configuration, 0, 11)
  job.set_grouping_comparator_class(Humboldt::JavaLib::BinaryComparator)
  Humboldt::JavaLib::BinaryComparator.set_offsets(job.configuration, 0, 11)
end
```

if you want to do secondary sort on a 12 byte suffix you can use -12 and -1 as the left and right offset for both the partitioner and comparator. The offsets are somehow based on Python string slicing, which I guess is more or less how Ruby's range slicing works too (it's just that you usually don't use ranges for slicing strings in Ruby). This means that if you want the first 12 bytes that's 0, 11 and not 0, 12 as you might expect if you're like me and assume the second argument is the length.