### PR TITLE
Remove RVM dependency for integration specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -74,14 +74,6 @@ namespace :setup do
     FileUtils.ln_sf(Dir["#{target_dir}/hadoop*"].sort.first[4..-1], current_link)
   end
 
-  task :test_project do
-    Dir.chdir('spec/fixtures/test_project') do
-      command = %Q{bash -l -c 'rvm use $RUBY_VERSION && rvm gemset create humboldt-test_project && rvm $RUBY_VERSION@humboldt-test_project do gem install bundler'}
-      puts command
-      Bundler.clean_system(command)
-    end
-  end
-
   task :classpath do
     File.open('.classpath', 'w') do |io|
       %x(#{current_link}/bin/hadoop classpath).chomp.split(':').each do |pattern|
@@ -94,7 +86,7 @@ namespace :setup do
 end
 
 desc 'Download Hadoop and set up the classpath configuration'
-task :setup => ['setup:hadoop', 'setup:test_project', 'setup:classpath']
+task :setup => ['setup:hadoop', 'setup:classpath']
 
 RSpec::Core::RakeTask.new(:spec) do |r|
   r.rspec_opts = '--tty'
@@ -102,4 +94,4 @@ RSpec::Core::RakeTask.new(:spec) do |r|
 end
 
 desc 'Build extensions and run the specs'
-task :spec => 'gem:build'
+task :spec => 'build:jars'

--- a/spec/fixtures/test_project/.gitignore
+++ b/spec/fixtures/test_project/.gitignore
@@ -9,3 +9,4 @@
 /another_file
 /Gemfile.lock
 /.bundle
+/vendor

--- a/spec/fixtures/test_project/Gemfile
+++ b/spec/fixtures/test_project/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org/'
 
-gem 'humboldt'
+gem 'humboldt', path: '../../..'
 
 group :development do
   gem 'rake'


### PR DESCRIPTION
This PR suggests enabling non-RVM users, such as myself, to run the integration specs.
